### PR TITLE
fix(package): use a valid SPDX license id

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "stats"
   ],
   "author": "See AUTHORS file.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/census-instrumentation/opencensus-js-core/issues"
   },


### PR DESCRIPTION
The correct SPDX license ID is Apache-2.0.